### PR TITLE
Bug Submitter: use the same dialog instance again after failure

### DIFF
--- a/src/main/java/Bug_Submitter/Bug_Submitter.java
+++ b/src/main/java/Bug_Submitter/Bug_Submitter.java
@@ -376,7 +376,7 @@ public class Bug_Submitter implements PlugIn {
 			suggestedUsername, suggestedPassword, systemInfo);
 
 		while( true ) {
-
+			dialog.resetForm();
 			GUI.center(dialog);
 			dialog.show();
 


### PR DESCRIPTION
This fixes Bug #816 in Fiji's bugzilla:
http://fiji.sc/bugzilla/show_bug.cgi?id=816

I had minor troubles when building with Maven: imagej-updater-0.3.9.jar gets deleted and replaced by an earlier version (0.2.0, or 0.3.6 if I removed the version tag in pom.xml). When I removed the imagej-updater dependency completely (thinking that it's implied by pom-fiji), I got compile errors, so I left it in, but had to put back the newest imagej-updater.jar in Fiji.app/jars in order to be able to start Fiji.
