### PR TITLE
Change assignee address to fix Bugzilla bug #829

### DIFF
--- a/src/main/java/Bug_Submitter/Bug_Submitter.java
+++ b/src/main/java/Bug_Submitter/Bug_Submitter.java
@@ -64,8 +64,6 @@ import net.imagej.updater.util.StderrProgress;
  */
 public class Bug_Submitter implements PlugIn {
 
-	protected String bugzillaAssignee = "fiji-devel@googlegroups.com";
-
 	public String e( String original ) {
 		try {
 			return URLEncoder.encode(original,"UTF-8");
@@ -286,8 +284,7 @@ public class Bug_Submitter implements PlugIn {
 				   "&version=unspecified"+
 				   "&bug_file_loc="+e("http://")+
 				   "&bug_status=NEW"+
-				   "&assigned_to="+e(bugzillaAssignee)+
-				   ccString+
+				   "&assigned_to="+ccString+
 				   "&estimated_time="+
 				   "&deadline="+
 				   "&short_desc="+e(bugSubject)+


### PR DESCRIPTION
I guess there should be a better solution than hard-coding the default assignee address, but that fixed Bug #829 ( http://fiji.sc/bugzilla/show_bug.cgi?id=829 ) for me.
